### PR TITLE
making the build compatible with heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/deploy.js
+++ b/deploy.js
@@ -1,0 +1,12 @@
+// Since postinstall will also run when you run npm install locally, we make sure it only runs in production
+if (process.env.NODE_ENV === 'production') {
+  // We just create a child process that will run the production bundle command
+  var child_process = require('child_process');
+  child_process.exec("npm run build", function (error, stdout, stderr) {
+    console.log('stdout: ' + stdout);
+    console.log('stderr: ' + stderr);
+    if (error !== null) {
+      console.log('exec error: ' + error);
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -2,10 +2,15 @@
   "name": "example-app",
   "version": "0.0.0",
   "private": true,
+  "config" : {
+    "port" : 3000
+  },
   "scripts": {
-    "start": "DEBUG=example-app PORT=3000 NODE_ENV=production node bin/www",
+    "start": "DEBUG=example-app NODE_ENV=production node bin/www",
+    "clean": "rm -rf www",
     "build": "NODE_ENV=production rm -rf www && webpack",
-    "dev": "DEBUG=example-app PORT=3000 NODE_ENV=development node bin/www",
+    "dev": "DEBUG=example-app NODE_ENV=development node bin/www",
+    "postinstall": "node deploy",
     "lint": "eslint .",
     "test": "echo todo: add tests"
   },

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -6,7 +6,7 @@ import debug from '../utils/debug';
 import app from './app';
 
 const isDev = app.get('env') === 'development';
-const port = parseInt(process.env.PORT, 10);
+const port = parseInt((process.env.PORT || process.env.npm_package_config_port), 10);
 const appPort = isDev ? port + 1 : port;
 const server = http.createServer(app);
 

--- a/webpackConfig/dev.js
+++ b/webpackConfig/dev.js
@@ -1,7 +1,7 @@
 var config = require('./common');
 var webpack = require('webpack');
 
-var port = parseInt(process.env.PORT);
+var port = parseInt(process.env.PORT || process.env.npm_package_config_port);
 var hotModuleReplacementPlugin = new webpack.HotModuleReplacementPlugin();
 
 Object.keys(config.entry).forEach(function (x) {


### PR DESCRIPTION
This lets you run it on heroku.

Note: It won't work on heroku right out of the box though unless you allow some of the devDependencies to load. This can be done with:
`heroku config:set NPM_CONFIG_PRODUCTION=false`
...Or another build process could be added to postinstall. 

Not sure if it's worth adding a note about that...

Looking good so far my friend!
